### PR TITLE
Github Action for deploy version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build and Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '1.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    name: Build JAR and Release
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build JAR with Maven
+        run: mvn clean package -DskipTests --file pom.xml
+        env:
+          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./target/*.jar
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
You can use this 'action' to release versions in a more automatic way, it will pull what you have written in your 'CHANGELOG.md'

It will trigger when sending a new tag to the repository, you can test using:
```sh
# create tag
git tag 1.x.x 

# push tags
git push --tags
```

If you want to keep the initial tags with 'v*' you need to change the yml:
```yml
on:
  workflow_dispatch:
  push:
    tags:
      # here
      - 'v1.*'
```
