### PR TITLE
DatePicker: add editor input validation check

### DIFF
--- a/src/main/java/raven/datetime/util/InputValidationListener.java
+++ b/src/main/java/raven/datetime/util/InputValidationListener.java
@@ -1,0 +1,12 @@
+package raven.datetime.util;
+
+import java.time.LocalDate;
+
+public interface InputValidationListener {
+
+    boolean isValidation();
+
+    void inputChanged(boolean isValid);
+
+    boolean checkDateSelectionAble(LocalDate date);
+}

--- a/src/test/java/test/TestDate.java
+++ b/src/test/java/test/TestDate.java
@@ -51,7 +51,7 @@ public class TestDate extends JFrame {
             }
         });
 
-        // datePicker.setDateSelectionAble((date) -> !date.isAfter(LocalDate.now()));
+        datePicker.setDateSelectionAble((date) -> !date.isAfter(LocalDate.now()));
         datePicker.now();
         JFormattedTextField editor = new JFormattedTextField();
         datePicker.setEditor(editor);
@@ -96,13 +96,23 @@ public class TestDate extends JFrame {
         });
         JCheckBox chDateOpt = new JCheckBox("Use Panel Option");
         chDateOpt.addActionListener(e -> datePicker.setUsePanelOption(chDateOpt.isSelected()));
-
         JCheckBox chClose = new JCheckBox("Close after selected");
         chClose.addActionListener(e -> datePicker.setCloseAfterSelected(chClose.isSelected()));
+
+        JCheckBox chEditorValidation = new JCheckBox("Editor validation", true);
+        JCheckBox chValidationOnNull = new JCheckBox("Validation on null");
+        chEditorValidation.addActionListener(e -> {
+            datePicker.setEditorValidation(chEditorValidation.isSelected());
+            chValidationOnNull.setEnabled(chEditorValidation.isSelected());
+        });
+
+        chValidationOnNull.addActionListener(e -> datePicker.setValidationOnNull(chValidationOnNull.isSelected()));
 
         panel.add(chBtw);
         panel.add(chDateOpt);
         panel.add(chClose);
+        panel.add(chEditorValidation);
+        panel.add(chValidationOnNull);
         add(panel);
     }
 


### PR DESCRIPTION
This PR update editor input validation

- By default it's enabled. to disable it use method: `datePicker.setEditorValidation(false);`

![2024-08-12_232723](https://github.com/user-attachments/assets/af5ec3f6-8734-4775-95f3-6f6e422824b9)

- Validateion on null selection. by default it's disabled. to enable use method `datePicker.setValidationOnNull(true)`

![2024-08-12_233524](https://github.com/user-attachments/assets/bbf8e200-5804-4628-a98f-701ec847038c)

- Validateion date selection able
When use `datepicker.setDateSelectionAble(dateSelectionAble)` to prevent users from selecting dates that are not allowed. This enhancement also ensures protection when users input dates directly in the editor.

#### Example
``` java
// create datepicker object
DatePicker datePicker = new DatePicker();

// set date selection able
// allow users to select only past or current dates
datePicker.setDateSelectionAble((date) -> !date.isAfter(LocalDate.now()));

// enable validation on null selection
datePicker.setValidationOnNull(true);

// create editor
JFormattedTextField editor = new JFormattedTextField();

// set datepicker editor
datePicker.setEditor(editor);
```
#### Output ( current date is `13/08/2024` )
![2024-08-13_000333](https://github.com/user-attachments/assets/6ad75811-1b7a-4e87-a86d-e714082013f8)

![2024-08-13_000616](https://github.com/user-attachments/assets/6188ec0e-b791-42f3-a708-8df20411ef6f)
