### PR TITLE
DatePicker: custom panel date option

### DIFF
--- a/src/main/java/raven/datetime/component/date/DatePicker.java
+++ b/src/main/java/raven/datetime/component/date/DatePicker.java
@@ -29,6 +29,7 @@ public class DatePicker extends JPanel {
     private PanelMonth.EventMonthChanged eventMonthChanged;
     private PanelYear.EventYearChanged eventYearChanged;
     private PanelDateOption panelDateOption;
+    private PanelDateOptionLabel panelDateOptionLabel;
     private InputUtils.ValueCallback valueCallback;
     private JFormattedTextField editor;
     private Icon editorIcon;
@@ -449,6 +450,7 @@ public class DatePicker extends JPanel {
             if (usePanelOption) {
                 if (panelDateOption == null) {
                     panelDateOption = new PanelDateOption(this);
+                    panelDateOption.installDateOptionLabel();
                 }
                 add(panelDateOption, "dock east,gap 0 10 10 10");
                 repaint();
@@ -461,6 +463,17 @@ public class DatePicker extends JPanel {
                     revalidate();
                 }
             }
+        }
+    }
+
+    public PanelDateOptionLabel getPanelDateOptionLabel() {
+        return panelDateOptionLabel;
+    }
+
+    public void setPanelDateOptionLabel(PanelDateOptionLabel panelDateOptionLabel) {
+        this.panelDateOptionLabel = panelDateOptionLabel;
+        if (panelDateOption != null) {
+            panelDateOption.installDateOptionLabel();
         }
     }
 

--- a/src/main/java/raven/datetime/component/date/PanelDateOption.java
+++ b/src/main/java/raven/datetime/component/date/PanelDateOption.java
@@ -61,6 +61,9 @@ public class PanelDateOption extends JPanel {
                 datePicker.clearSelectedDate();
             } else {
                 LocalDate[] dates = callback.getDate();
+                if (dates.length == 0) {
+                    throw new IllegalArgumentException("Date option is empty so can't be select");
+                }
                 boolean singleDate = dates.length == 1 || datePicker.getDateSelectionMode() == DatePicker.DateSelectionMode.SINGLE_DATE_SELECTED;
                 if (singleDate) {
                     datePicker.setSelectedDate(dates[0]);

--- a/src/main/java/raven/datetime/component/date/PanelDateOptionLabel.java
+++ b/src/main/java/raven/datetime/component/date/PanelDateOptionLabel.java
@@ -1,0 +1,72 @@
+package raven.datetime.component.date;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PanelDateOptionLabel {
+
+    private final List<Item> listItems = new ArrayList<>();
+
+    public PanelDateOptionLabel() {
+    }
+
+    public void add(String label, LabelCallback callback) {
+        listItems.add(new Item(label, callback));
+    }
+
+    public List<Item> getListItems() {
+        return listItems;
+    }
+
+    private void remove(int index) {
+        listItems.remove(index);
+    }
+
+    private void clear() {
+        listItems.clear();
+    }
+
+    public class Item {
+
+        public String getLabel() {
+            return label;
+        }
+
+        public LabelCallback getCallback() {
+            return callback;
+        }
+
+        public Item(String label, LabelCallback callback) {
+            this.label = label;
+            this.callback = callback;
+        }
+
+        private final String label;
+        private final LabelCallback callback;
+    }
+
+    public interface LabelCallback {
+
+        LabelCallback TODAY = () -> new LocalDate[]{LocalDate.now()};
+        LabelCallback YESTERDAY = () -> new LocalDate[]{LocalDate.now().minusDays(1)};
+        LabelCallback LAST_7_DAYS = () -> new LocalDate[]{LocalDate.now().minusDays(7), LocalDate.now()};
+        LabelCallback LAST_30_DAYS = () -> new LocalDate[]{LocalDate.now().minusDays(30), LocalDate.now()};
+        LabelCallback THIS_MONTH = () -> {
+            LocalDate now = LocalDate.now();
+            return new LocalDate[]{now.withDayOfMonth(1), now.withDayOfMonth(now.lengthOfMonth())};
+        };
+        LabelCallback LAST_MONTH = () -> {
+            LocalDate lastMonth = LocalDate.now().minusMonths(1);
+            return new LocalDate[]{lastMonth.withDayOfMonth(1), lastMonth.withDayOfMonth(lastMonth.lengthOfMonth())};
+        };
+        LabelCallback LAST_YEAR = () -> {
+            LocalDate lastYear = LocalDate.now().minusYears(1).withDayOfYear(1);
+            return new LocalDate[]{lastYear, lastYear.withDayOfYear(lastYear.lengthOfYear())};
+        };
+
+        LabelCallback CUSTOM = null;
+
+        LocalDate[] getDate();
+    }
+}

--- a/src/test/java/test/TestDate.java
+++ b/src/test/java/test/TestDate.java
@@ -51,7 +51,8 @@ public class TestDate extends JFrame {
             }
         });
 
-        datePicker.setDateSelectionAble((date) -> !date.isAfter(LocalDate.now()));
+        // datePicker.setDateSelectionAble((date) -> !date.isAfter(LocalDate.now()));
+
         datePicker.now();
         JFormattedTextField editor = new JFormattedTextField();
         datePicker.setEditor(editor);


### PR DESCRIPTION
This PR add `PanelDateOptionLabel` to custom panel date option in `DatePicker` component

To enable panel date option

``` java
datePicker.setUsePanelOption(true);
```

Custom panel date option label

``` java
// create PanelDateOptionLabel
PanelDateOptionLabel panelDateOptionLabel = new PanelDateOptionLabel();

// add custom label
panelDateOptionLabel.add("Today", PanelDateOptionLabel.LabelCallback.TODAY);
panelDateOptionLabel.add("Last 30 days", PanelDateOptionLabel.LabelCallback.LAST_30_DAYS);
panelDateOptionLabel.add("Last 28 days", () -> new LocalDate[]{LocalDate.now().minusDays(28), LocalDate.now()});

panelDateOptionLabel.add("Clear", PanelDateOptionLabel.LabelCallback.CUSTOM);

// apply this custom to DatePicker
datePicker.setPanelDateOptionLabel(panelDateOptionLabel);
```

![2024-11-21_195841](https://github.com/user-attachments/assets/68d62448-5fbf-465e-87b6-e3d82a3da04a)
