### PR TITLE
TimePicker: add time selection able and editor input validation check

### DIFF
--- a/src/main/java/raven/datetime/DatePicker.java
+++ b/src/main/java/raven/datetime/DatePicker.java
@@ -30,7 +30,7 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
     private DateTimeFormatter format;
     private String dateFormatPattern = "dd/MM/yyyy";
     private DateSelectionListener dateSelectionListener;
-    private InputValidationListener inputValidationListener;
+    private InputValidationListener<LocalDate> inputValidationListener;
     private DateSelectionModel dateSelectionModel;
     private PanelDateOption panelDateOption;
     private PanelDateOptionLabel panelDateOptionLabel;
@@ -606,7 +606,7 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
 
     private InputValidationListener getInputValidationListener() {
         if (inputValidationListener == null) {
-            inputValidationListener = new InputValidationListener() {
+            inputValidationListener = new InputValidationListener<LocalDate>() {
 
                 @Override
                 public boolean isValidation() {
@@ -619,7 +619,7 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
                 }
 
                 @Override
-                public boolean checkDateSelectionAble(LocalDate date) {
+                public boolean checkSelectionAble(LocalDate date) {
                     if (dateSelectionModel.getDateSelectionAble() == null) return true;
                     return dateSelectionModel.getDateSelectionAble().isDateSelectedAble(date);
                 }

--- a/src/main/java/raven/datetime/DatePicker.java
+++ b/src/main/java/raven/datetime/DatePicker.java
@@ -21,7 +21,6 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
-import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -44,11 +43,6 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
     private int year = 2023;
     private Color color;
     private JButton editorButton;
-    private boolean editorValidation = true;
-    private boolean isValid;
-    private boolean validationOnNull;
-    private String defaultPlaceholder;
-
     private SelectionState selectionState = SelectionState.DATE;
     private PanelDate panelDate;
     private PanelMonth panelMonth;
@@ -243,6 +237,7 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
         if (selectionState == SelectionState.DATE) {
             panelDate.load();
         }
+        commitEdit();
     }
 
     public Color getColor() {
@@ -287,34 +282,6 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
                 this.defaultPlaceholder = null;
             }
             this.dateFormatPattern = format;
-        }
-    }
-
-    public boolean isEditorValidation() {
-        return editorValidation;
-    }
-
-    public void setEditorValidation(boolean editorValidation) {
-        if (this.editorValidation != editorValidation) {
-            this.editorValidation = editorValidation;
-            if (editor != null) {
-                if (editorValidation) {
-                    validChanged(editor, isValid);
-                } else {
-                    validChanged(editor, true);
-                }
-            }
-        }
-    }
-
-    public boolean isValidationOnNull() {
-        return validationOnNull;
-    }
-
-    public void setValidationOnNull(boolean validationOnNull) {
-        if (this.validationOnNull != validationOnNull) {
-            this.validationOnNull = validationOnNull;
-            commitEdit();
         }
     }
 
@@ -628,31 +595,8 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
         return inputValidationListener;
     }
 
-    private void checkValidation(boolean status) {
-        boolean valid = status || isEditorValidationOnNull();
-        if (isValid != valid) {
-            isValid = valid;
-            if (editor != null) {
-                if (editorValidation) {
-                    validChanged(editor, valid);
-                }
-            }
-        }
-    }
-
-    private void validChanged(JFormattedTextField editor, boolean isValid) {
-        String style = isValid ? null : FlatClientProperties.OUTLINE_ERROR;
-        editor.putClientProperty(FlatClientProperties.OUTLINE, style);
-    }
-
-    private boolean isEditorValidationOnNull() {
-        if (validationOnNull) {
-            return false;
-        }
-        return editor == null || editor.getText().equals(getDefaultPlaceholder());
-    }
-
-    private String getDefaultPlaceholder() {
+    @Override
+    protected String getDefaultPlaceholder() {
         if (defaultPlaceholder == null) {
             if (getDateSelectionMode() == DateSelectionMode.BETWEEN_DATE_SELECTED) {
                 String d = InputUtils.datePatternToInputFormat(dateFormatPattern, "-");
@@ -662,15 +606,6 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
             }
         }
         return defaultPlaceholder;
-    }
-
-    private void commitEdit() {
-        if (editor != null && editorValidation) {
-            try {
-                editor.commitEdit();
-            } catch (ParseException e) {
-            }
-        }
     }
 
     private void verifyDateSelection() {

--- a/src/main/java/raven/datetime/TimePicker.java
+++ b/src/main/java/raven/datetime/TimePicker.java
@@ -13,6 +13,7 @@ import raven.datetime.component.time.event.TimeSelectionModelListener;
 import raven.datetime.event.TimeSelectionEvent;
 import raven.datetime.event.TimeSelectionListener;
 import raven.datetime.util.InputUtils;
+import raven.datetime.util.InputValidationListener;
 
 import javax.swing.*;
 import java.awt.*;
@@ -26,6 +27,7 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
     private final DateTimeFormatter format24h = DateTimeFormatter.ofPattern("HH:mm", Locale.ENGLISH);
     private TimeSelectionModel timeSelectionModel;
     private TimeSelectionListener timeSelectionListener;
+    private InputValidationListener<LocalTime> inputValidationListener;
     private InputUtils.ValueCallback valueCallback;
     private Icon editorIcon;
     private MigLayout layout;
@@ -104,7 +106,7 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
             header.updateHeader();
             repaint();
             if (editor != null) {
-                InputUtils.changeTimeFormatted(editor, hour24);
+                InputUtils.changeTimeFormatted(editor, hour24, getInputValidationListener());
                 setEditorValue();
             }
         }
@@ -220,7 +222,7 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
                 showPopup();
             }
         });
-        InputUtils.useTimeInput(editor, panelClock.isUse24hour(), getValueCallback());
+        InputUtils.useTimeInput(editor, panelClock.isUse24hour(), getValueCallback(), getInputValidationListener());
         setEditorValue();
         editor.putClientProperty(FlatClientProperties.TEXT_FIELD_TRAILING_COMPONENT, toolBar);
         addTimeSelectionListener(getTimeSelectionListener());
@@ -272,6 +274,30 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
         } else {
             editor.setValue(null);
         }
+    }
+
+    private InputValidationListener getInputValidationListener() {
+        if (inputValidationListener == null) {
+            inputValidationListener = new InputValidationListener<LocalTime>() {
+
+                @Override
+                public boolean isValidation() {
+                    return timeSelectionModel.getTimeSelectionAble() != null;
+                }
+
+                @Override
+                public void inputChanged(boolean status) {
+                }
+
+                @Override
+                public boolean checkSelectionAble(LocalTime time) {
+                    int hour = time.getHour();
+                    int minute = time.getMinute();
+                    return timeSelectionModel.checkSelection(hour, minute);
+                }
+            };
+        }
+        return inputValidationListener;
     }
 
     private void verifyTimeSelection() {

--- a/src/main/java/raven/datetime/TimePicker.java
+++ b/src/main/java/raven/datetime/TimePicker.java
@@ -90,6 +90,11 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
             this.editor = editor;
             if (editor != null) {
                 installEditor(editor);
+                if (editorValidation) {
+                    validChanged(editor, isValid);
+                } else {
+                    validChanged(editor, true);
+                }
             }
         }
     }
@@ -107,6 +112,7 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
             repaint();
             if (editor != null) {
                 InputUtils.changeTimeFormatted(editor, hour24, getInputValidationListener());
+                this.defaultPlaceholder = null;
                 setEditorValue();
             }
         }
@@ -184,6 +190,7 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
 
     public void setTimeSelectionAble(TimeSelectionAble timeSelectionAble) {
         timeSelectionModel.setTimeSelectionAble(timeSelectionAble);
+        commitEdit();
     }
 
     public TimeSelectionModel getTimeSelectionModel() {
@@ -287,6 +294,7 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
 
                 @Override
                 public void inputChanged(boolean status) {
+                    checkValidation(status);
                 }
 
                 @Override
@@ -298,6 +306,20 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
             };
         }
         return inputValidationListener;
+    }
+
+    @Override
+    protected String getDefaultPlaceholder() {
+        if (defaultPlaceholder == null) {
+            String pattern;
+            if (is24HourView()) {
+                pattern = "--:--";
+            } else {
+                pattern = "--:-- --";
+            }
+            defaultPlaceholder = pattern;
+        }
+        return defaultPlaceholder;
     }
 
     private void verifyTimeSelection() {

--- a/src/main/java/raven/datetime/TimePicker.java
+++ b/src/main/java/raven/datetime/TimePicker.java
@@ -176,6 +176,14 @@ public class TimePicker extends PanelPopupEditor implements TimeSelectionModelLi
         return new TimeSelectionModel();
     }
 
+    public TimeSelectionAble getTimeSelectionAble() {
+        return timeSelectionModel.getTimeSelectionAble();
+    }
+
+    public void setTimeSelectionAble(TimeSelectionAble timeSelectionAble) {
+        timeSelectionModel.setTimeSelectionAble(timeSelectionAble);
+    }
+
     public TimeSelectionModel getTimeSelectionModel() {
         return timeSelectionModel;
     }

--- a/src/main/java/raven/datetime/TimeSelectionAble.java
+++ b/src/main/java/raven/datetime/TimeSelectionAble.java
@@ -4,5 +4,5 @@ import java.time.LocalTime;
 
 public interface TimeSelectionAble {
 
-    boolean isTimeSelectedAble(LocalTime time);
+    boolean isTimeSelectedAble(LocalTime time, boolean hourView);
 }

--- a/src/main/java/raven/datetime/TimeSelectionAble.java
+++ b/src/main/java/raven/datetime/TimeSelectionAble.java
@@ -1,0 +1,8 @@
+package raven.datetime;
+
+import java.time.LocalTime;
+
+public interface TimeSelectionAble {
+
+    boolean isTimeSelectedAble(LocalTime time);
+}

--- a/src/main/java/raven/datetime/component/PanelPopupEditor.java
+++ b/src/main/java/raven/datetime/component/PanelPopupEditor.java
@@ -5,13 +5,19 @@ import raven.datetime.util.Utils;
 
 import javax.swing.*;
 import java.awt.*;
+import java.text.ParseException;
 
-public class PanelPopupEditor extends JPanel {
+public abstract class PanelPopupEditor extends JPanel {
 
     protected JFormattedTextField editor;
     protected JPopupMenu popupMenu;
-    protected LookAndFeel oldThemes = UIManager.getLookAndFeel();
 
+    protected boolean editorValidation = true;
+    protected boolean isValid;
+    protected boolean validationOnNull;
+    protected String defaultPlaceholder;
+
+    protected LookAndFeel oldThemes = UIManager.getLookAndFeel();
 
     public PanelPopupEditor() {
     }
@@ -39,4 +45,67 @@ public class PanelPopupEditor extends JPanel {
             repaint();
         }
     }
+
+    public boolean isEditorValidation() {
+        return editorValidation;
+    }
+
+    public void setEditorValidation(boolean editorValidation) {
+        if (this.editorValidation != editorValidation) {
+            this.editorValidation = editorValidation;
+            if (editor != null) {
+                if (editorValidation) {
+                    validChanged(editor, isValid);
+                } else {
+                    validChanged(editor, true);
+                }
+            }
+        }
+    }
+
+    public boolean isValidationOnNull() {
+        return validationOnNull;
+    }
+
+    public void setValidationOnNull(boolean validationOnNull) {
+        if (this.validationOnNull != validationOnNull) {
+            this.validationOnNull = validationOnNull;
+            commitEdit();
+        }
+    }
+
+    protected void checkValidation(boolean status) {
+        boolean valid = status || isEditorValidationOnNull();
+        if (isValid != valid) {
+            isValid = valid;
+            if (editor != null) {
+                if (editorValidation) {
+                    validChanged(editor, valid);
+                }
+            }
+        }
+    }
+
+    protected void validChanged(JFormattedTextField editor, boolean isValid) {
+        String style = isValid ? null : FlatClientProperties.OUTLINE_ERROR;
+        editor.putClientProperty(FlatClientProperties.OUTLINE, style);
+    }
+
+    protected boolean isEditorValidationOnNull() {
+        if (validationOnNull) {
+            return false;
+        }
+        return editor != null && editor.getText().equals(getDefaultPlaceholder());
+    }
+
+    protected void commitEdit() {
+        if (editor != null && editorValidation) {
+            try {
+                editor.commitEdit();
+            } catch (ParseException e) {
+            }
+        }
+    }
+
+    protected abstract String getDefaultPlaceholder();
 }

--- a/src/main/java/raven/datetime/component/time/Header.java
+++ b/src/main/java/raven/datetime/component/time/Header.java
@@ -136,6 +136,9 @@ public class Header extends JComponent {
         int minute = timeSelectionModel.getMinute();
         if (hour == -1 && minute == -1) {
             setSelectedAm(isAm);
+
+            // need to repaint the panel clock to update the paint text selection able
+            timePicker.repaint();
         } else {
             if (isAm) {
                 if (hour >= 12) {

--- a/src/main/java/raven/datetime/component/time/PanelClock.java
+++ b/src/main/java/raven/datetime/component/time/PanelClock.java
@@ -158,6 +158,7 @@ public class PanelClock extends JPanel {
     }
 
     protected void paintClockNumber(Graphics2D g2, int x, int y, int size, int margin, int start, int add) {
+        TimeSelectionModel timeSelectionModel = timePicker.getTimeSelectionModel();
         final int mg = UIScale.scale(margin);
         float center = size / 2f;
         float angle = 360 / 12;
@@ -166,7 +167,17 @@ public class PanelClock extends JPanel {
             int value = fixHour((start + i * add), hourSelectionView);
             float nx = (float) (center + (Math.cos(Math.toRadians(ag)) * (center - mg)));
             float ny = (float) (center + (Math.sin(Math.toRadians(ag)) * (center - mg)));
-            boolean isSelectedAble = true;
+
+            int hour;
+            int minute;
+            if (hourSelectionView) {
+                hour = valueToTime(value, true);
+                minute = 0;
+            } else {
+                hour = timeSelectionModel.getHour();
+                minute = value;
+            }
+            boolean isSelectedAble = timeSelectionModel.checkSelection(hour, minute);
             paintNumber(g2, x + nx, y + ny, fixNumberAndToString(value), isSelected(value), isSelectedAble);
         }
     }
@@ -336,6 +347,23 @@ public class PanelClock extends JPanel {
             hour = (timePicker.getHeader().isAm() ? hour : hour - 12);
             return hour == 0 ? 12 : hour;
         }
+    }
+
+    private int valueToTime(int value, boolean hourView) {
+        if (!hourView) {
+            return value;
+        }
+        if (!isUse24hour()) {
+            boolean isAm = timePicker.getHeader().isAm();
+            value += isAm ? 0 : 12;
+            if (isAm && value == 12) {
+                return 0;
+            }
+            if (!isAm && value == 24) {
+                return 12;
+            }
+        }
+        return value;
     }
 
     private boolean is24hour() {

--- a/src/main/java/raven/datetime/component/time/PanelClock.java
+++ b/src/main/java/raven/datetime/component/time/PanelClock.java
@@ -172,7 +172,7 @@ public class PanelClock extends JPanel {
             int minute;
             if (hourSelectionView) {
                 hour = valueToTime(value, true);
-                minute = 0;
+                minute = timeSelectionModel.getMinute();
             } else {
                 hour = timeSelectionModel.getHour();
                 minute = value;

--- a/src/main/java/raven/datetime/component/time/TimeSelectionModel.java
+++ b/src/main/java/raven/datetime/component/time/TimeSelectionModel.java
@@ -92,6 +92,36 @@ public class TimeSelectionModel {
      * So we need set the default hour
      */
     public int getDefaultSelectionHour() {
+        int defaultHour = 0;
+        if (timeSelectionAble != null) {
+            defaultHour = getAvailableDefaultHour(defaultHour);
+        }
+        return defaultHour;
+    }
+
+    /**
+     * Default hour can be disabled by timeSelectionAble
+     * Use this method to get the available hour
+     */
+    private int getAvailableDefaultHour(int startHour) {
+        int hour = startHour;
+        for (int i = 0; i < 23; i++) {
+            if (checkSelection(hour, getDefaultMinuteCheck())) {
+                return hour;
+            }
+            hour++;
+            if (hour == 24) {
+                hour = 0;
+            }
+        }
+        return startHour;
+    }
+
+    /**
+     * When check time selection able but minute not set
+     * Use this for default minute to check the available hour
+     */
+    private int getDefaultMinuteCheck() {
         return 0;
     }
 
@@ -100,11 +130,10 @@ public class TimeSelectionModel {
             return true;
         }
         if (minute == -1) {
-            minute = 0;
+            minute = getDefaultMinuteCheck();
         }
         return timeSelectionAble.isTimeSelectedAble(LocalTime.of(hour, minute));
     }
-
 
     public void addTimePickerSelectionListener(TimeSelectionModelListener listener) {
         listenerList.add(TimeSelectionModelListener.class, listener);

--- a/src/main/java/raven/datetime/component/time/TimeSelectionModel.java
+++ b/src/main/java/raven/datetime/component/time/TimeSelectionModel.java
@@ -1,5 +1,6 @@
 package raven.datetime.component.time;
 
+import raven.datetime.TimeSelectionAble;
 import raven.datetime.component.time.event.TimeSelectionModelEvent;
 import raven.datetime.component.time.event.TimeSelectionModelListener;
 
@@ -9,10 +10,19 @@ import java.time.LocalTime;
 public class TimeSelectionModel {
 
     protected EventListenerList listenerList = new EventListenerList();
+    private TimeSelectionAble timeSelectionAble;
     private int hour = -1;
     private int minute = -1;
 
     public TimeSelectionModel() {
+    }
+
+    public TimeSelectionAble getTimeSelectionAble() {
+        return timeSelectionAble;
+    }
+
+    public void setTimeSelectionAble(TimeSelectionAble timeSelectionAble) {
+        this.timeSelectionAble = timeSelectionAble;
     }
 
     public int getHour() {
@@ -20,6 +30,9 @@ public class TimeSelectionModel {
     }
 
     public void setHour(int hour) {
+        if (!checkSelection(hour, minute)) {
+            return;
+        }
         if (this.hour != hour) {
             this.hour = hour;
             fireTimePickerChanged(new TimeSelectionModelEvent(this, TimeSelectionModelEvent.HOUR));
@@ -35,6 +48,9 @@ public class TimeSelectionModel {
             set(getDefaultSelectionHour(), minute);
         } else {
             if (this.minute != minute) {
+                if (!checkSelection(hour, minute)) {
+                    return;
+                }
                 this.minute = minute;
                 fireTimePickerChanged(new TimeSelectionModelEvent(this, TimeSelectionModelEvent.MINUTE));
             }
@@ -62,6 +78,9 @@ public class TimeSelectionModel {
             action = TimeSelectionModelEvent.MINUTE;
         }
         if (action != 0) {
+            if (!checkSelection(hour, minute)) {
+                return;
+            }
             this.hour = hour;
             this.minute = minute;
             fireTimePickerChanged(new TimeSelectionModelEvent(this, action));
@@ -75,6 +94,17 @@ public class TimeSelectionModel {
     public int getDefaultSelectionHour() {
         return 0;
     }
+
+    public boolean checkSelection(int hour, int minute) {
+        if (timeSelectionAble == null || hour == -1 || (minute == -1 && hour == -1)) {
+            return true;
+        }
+        if (minute == -1) {
+            minute = 0;
+        }
+        return timeSelectionAble.isTimeSelectedAble(LocalTime.of(hour, minute));
+    }
+
 
     public void addTimePickerSelectionListener(TimeSelectionModelListener listener) {
         listenerList.add(TimeSelectionModelListener.class, listener);

--- a/src/main/java/raven/datetime/component/time/TimeSelectionModel.java
+++ b/src/main/java/raven/datetime/component/time/TimeSelectionModel.java
@@ -45,7 +45,7 @@ public class TimeSelectionModel {
 
     public void setMinute(int minute) {
         if (hour == -1) {
-            set(getDefaultSelectionHour(), minute);
+            set(getDefaultSelectionHour(minute), minute);
         } else {
             if (this.minute != minute) {
                 if (!checkSelection(hour, minute)) {
@@ -91,10 +91,10 @@ public class TimeSelectionModel {
      * When hour unselected and user select the minute
      * So we need set the default hour
      */
-    public int getDefaultSelectionHour() {
+    public int getDefaultSelectionHour(int minute) {
         int defaultHour = 0;
         if (timeSelectionAble != null) {
-            defaultHour = getAvailableDefaultHour(defaultHour);
+            defaultHour = getAvailableDefaultHour(defaultHour, minute);
         }
         return defaultHour;
     }
@@ -103,10 +103,10 @@ public class TimeSelectionModel {
      * Default hour can be disabled by timeSelectionAble
      * Use this method to get the available hour
      */
-    private int getAvailableDefaultHour(int startHour) {
+    private int getAvailableDefaultHour(int startHour, int minute) {
         int hour = startHour;
         for (int i = 0; i < 23; i++) {
-            if (checkSelection(hour, getDefaultMinuteCheck())) {
+            if (checkSelection(hour, minute)) {
                 return hour;
             }
             hour++;
@@ -129,10 +129,13 @@ public class TimeSelectionModel {
         if (timeSelectionAble == null || hour == -1 || (minute == -1 && hour == -1)) {
             return true;
         }
+        // hourView true if only hour are set. use to display the hour on the PanelClock
+        boolean hourView = false;
         if (minute == -1) {
             minute = getDefaultMinuteCheck();
+            hourView = true;
         }
-        return timeSelectionAble.isTimeSelectedAble(LocalTime.of(hour, minute));
+        return timeSelectionAble.isTimeSelectedAble(LocalTime.of(hour, minute), hourView);
     }
 
     public void addTimePickerSelectionListener(TimeSelectionModelListener listener) {

--- a/src/main/java/raven/datetime/util/InputUtils.java
+++ b/src/main/java/raven/datetime/util/InputUtils.java
@@ -163,13 +163,11 @@ public class InputUtils extends MaskFormatter {
 
     private static class TimeInputFormat extends MaskFormatter {
 
-        private final boolean use24h;
         private InputValidationListener inputValidationListener;
         private DateTimeFormatter timeFormat;
 
         public TimeInputFormat(String mark, boolean use24h, InputValidationListener inputValidationListener) throws ParseException {
             super(mark);
-            this.use24h = use24h;
             this.inputValidationListener = inputValidationListener;
             this.timeFormat = new DateTimeFormatterBuilder()
                     .parseCaseInsensitive()
@@ -192,7 +190,7 @@ public class InputUtils extends MaskFormatter {
                 // validate time selection able
                 if (inputValidationListener.isValidation()) {
                     if (!inputValidationListener.checkSelectionAble(time)) {
-                        throw new ParseException("error selection able", 0);
+                        throw new DateTimeException("error selection able");
                     }
                 }
                 inputValidationListener.inputChanged(true);

--- a/src/main/java/raven/datetime/util/InputUtils.java
+++ b/src/main/java/raven/datetime/util/InputUtils.java
@@ -10,10 +10,12 @@ import java.beans.PropertyChangeListener;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -62,9 +64,9 @@ public class InputUtils extends MaskFormatter {
         }
     }
 
-    public static void useTimeInput(JFormattedTextField txt, boolean use24h, ValueCallback callback) {
+    public static void useTimeInput(JFormattedTextField txt, boolean use24h, ValueCallback callback, InputValidationListener inputValidationListener) {
         try {
-            TimeInputFormat mask = new TimeInputFormat(use24h ? "##:##" : "##:## ??", use24h);
+            TimeInputFormat mask = new TimeInputFormat(use24h ? "##:##" : "##:## ??", use24h, inputValidationListener);
             OldEditorProperty oldEditorProperty = initEditor(txt, mask, callback);
 
             PropertyChangeListener propertyChangeListener = evt -> callback.valueChanged(txt.getValue());
@@ -93,9 +95,9 @@ public class InputUtils extends MaskFormatter {
         }
     }
 
-    public static void changeTimeFormatted(JFormattedTextField txt, boolean use24h) {
+    public static void changeTimeFormatted(JFormattedTextField txt, boolean use24h, InputValidationListener inputValidationListener) {
         try {
-            TimeInputFormat mask = new TimeInputFormat(use24h ? "##:##" : "##:## ??", use24h);
+            TimeInputFormat mask = new TimeInputFormat(use24h ? "##:##" : "##:## ??", use24h, inputValidationListener);
             mask.setCommitsOnValidEdit(true);
             mask.setPlaceholderCharacter('-');
             DefaultFormatterFactory df = new DefaultFormatterFactory(mask);
@@ -162,10 +164,17 @@ public class InputUtils extends MaskFormatter {
     private static class TimeInputFormat extends MaskFormatter {
 
         private final boolean use24h;
+        private InputValidationListener inputValidationListener;
+        private DateTimeFormatter timeFormat;
 
-        public TimeInputFormat(String mark, boolean use24h) throws ParseException {
+        public TimeInputFormat(String mark, boolean use24h, InputValidationListener inputValidationListener) throws ParseException {
             super(mark);
             this.use24h = use24h;
+            this.inputValidationListener = inputValidationListener;
+            this.timeFormat = new DateTimeFormatterBuilder()
+                    .parseCaseInsensitive()
+                    .appendPattern(use24h ? "HH:mm" : "hh:mm a")
+                    .toFormatter(Locale.ENGLISH);
         }
 
         @Override
@@ -175,9 +184,24 @@ public class InputUtils extends MaskFormatter {
         }
 
         public void checkTime(String value) throws ParseException {
-            DateFormat df = new SimpleDateFormat(use24h ? "HH:mm" : "hh:mm aa");
-            df.setLenient(false);
-            df.parse(value);
+            try {
+                LocalTime time = LocalTime.parse(value, timeFormat);
+
+                if (inputValidationListener == null) return;
+
+                // validate time selection able
+                if (inputValidationListener.isValidation()) {
+                    if (!inputValidationListener.checkSelectionAble(time)) {
+                        throw new ParseException("error selection able", 0);
+                    }
+                }
+                inputValidationListener.inputChanged(true);
+            } catch (DateTimeException e) {
+                if (inputValidationListener != null) {
+                    inputValidationListener.inputChanged(false);
+                }
+                throw new ParseException(e.getMessage(), 0);
+            }
         }
     }
 
@@ -216,8 +240,8 @@ public class InputUtils extends MaskFormatter {
                     if (inputValidationListener.isValidation()) {
                         LocalDate date1 = dateToLocalDate(fromDate);
                         LocalDate date2 = dateToLocalDate(toDate);
-                        if (!inputValidationListener.checkDateSelectionAble(date1) ||
-                                !inputValidationListener.checkDateSelectionAble(date2)) {
+                        if (!inputValidationListener.checkSelectionAble(date1) ||
+                                !inputValidationListener.checkSelectionAble(date2)) {
                             throw new ParseException("error selection able", 0);
                         }
                     }
@@ -229,7 +253,7 @@ public class InputUtils extends MaskFormatter {
                     // validate date selection able
                     if (inputValidationListener.isValidation()) {
                         LocalDate d = dateToLocalDate(date);
-                        if (!inputValidationListener.checkDateSelectionAble(d)) {
+                        if (!inputValidationListener.checkSelectionAble(d)) {
                             throw new ParseException("error selection able", 0);
                         }
                     }

--- a/src/main/java/raven/datetime/util/InputValidationListener.java
+++ b/src/main/java/raven/datetime/util/InputValidationListener.java
@@ -1,12 +1,10 @@
 package raven.datetime.util;
 
-import java.time.LocalDate;
-
-public interface InputValidationListener {
+public interface InputValidationListener<T> {
 
     boolean isValidation();
 
     void inputChanged(boolean isValid);
 
-    boolean checkDateSelectionAble(LocalDate date);
+    boolean checkSelectionAble(T data);
 }

--- a/src/test/java/test/TestTime.java
+++ b/src/test/java/test/TestTime.java
@@ -31,7 +31,18 @@ public class TestTime extends TestFrame {
         // set enable selection time from
         // 0 to 19:30 or
         // 12:00 am to 07:30 pm
-        timePicker.setTimeSelectionAble((time) -> !time.isAfter(LocalTime.of(19, 30)));
+        // timePicker.setTimeSelectionAble((time, hourView) -> !time.isAfter(LocalTime.of(19, 30)));
+
+
+        // disable the past
+        timePicker.setTimeSelectionAble((time, hourView) -> {
+            LocalTime now = LocalTime.now().withSecond(0).withNano(0);
+            if (hourView) {
+                // use this to enable the hour selection on the PanelClock
+                return time.getHour() >= now.getHour();
+            }
+            return !time.isBefore(now);
+        });
 
         timePicker.now();
 

--- a/src/test/java/test/TestTime.java
+++ b/src/test/java/test/TestTime.java
@@ -9,6 +9,7 @@ import raven.datetime.TimePicker;
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 public class TestTime extends TestFrame {
@@ -26,6 +27,14 @@ public class TestTime extends TestFrame {
                 System.out.println("event selected : null");
             }
         });
+
+        // set enable selection time from
+        // 0 to 19:30 or
+        // 12:00 am to 07:30 pm
+        timePicker.setTimeSelectionAble((time) -> !time.isAfter(LocalTime.of(19, 30)));
+
+        timePicker.now();
+
         JFormattedTextField editor = new JFormattedTextField();
         timePicker.setEditor(editor);
         add(editor, "width 200");

--- a/src/test/java/test/TestTime.java
+++ b/src/test/java/test/TestTime.java
@@ -47,6 +47,8 @@ public class TestTime extends TestFrame {
         JCheckBox ch24hourView = new JCheckBox("24 hour view");
         JCheckBox chHorizontal = new JCheckBox("Horizontal");
         JCheckBox chDisablePast = new JCheckBox("Disable past");
+        JCheckBox chEditorValidation = new JCheckBox("Editor validation", timePicker.isEditorValidation());
+        JCheckBox chValidationOnNull = new JCheckBox("Validation on null");
         ch24hourView.addActionListener(e -> {
             timePicker.set24HourView(ch24hourView.isSelected());
         });
@@ -59,9 +61,18 @@ public class TestTime extends TestFrame {
                 timePicker.setTimeSelectionAble(null);
             }
         });
+        chEditorValidation.addActionListener(e -> {
+            timePicker.setEditorValidation(chEditorValidation.isSelected());
+            chValidationOnNull.setEnabled(chEditorValidation.isSelected());
+        });
+
+        chValidationOnNull.addActionListener(e -> timePicker.setValidationOnNull(chValidationOnNull.isSelected()));
+
         panel.add(ch24hourView);
         panel.add(chHorizontal);
         panel.add(chDisablePast);
+        panel.add(chEditorValidation);
+        panel.add(chValidationOnNull);
         add(panel);
     }
 

--- a/src/test/java/test/TestTime.java
+++ b/src/test/java/test/TestTime.java
@@ -33,17 +33,6 @@ public class TestTime extends TestFrame {
         // 12:00 am to 07:30 pm
         // timePicker.setTimeSelectionAble((time, hourView) -> !time.isAfter(LocalTime.of(19, 30)));
 
-
-        // disable the past
-        timePicker.setTimeSelectionAble((time, hourView) -> {
-            LocalTime now = LocalTime.now().withSecond(0).withNano(0);
-            if (hourView) {
-                // use this to enable the hour selection on the PanelClock
-                return time.getHour() >= now.getHour();
-            }
-            return !time.isBefore(now);
-        });
-
         timePicker.now();
 
         JFormattedTextField editor = new JFormattedTextField();
@@ -57,15 +46,35 @@ public class TestTime extends TestFrame {
         panel.setBorder(new TitledBorder("Option"));
         JCheckBox ch24hourView = new JCheckBox("24 hour view");
         JCheckBox chHorizontal = new JCheckBox("Horizontal");
+        JCheckBox chDisablePast = new JCheckBox("Disable past");
         ch24hourView.addActionListener(e -> {
             timePicker.set24HourView(ch24hourView.isSelected());
         });
         chHorizontal.addActionListener(e -> timePicker.setOrientation(chHorizontal.isSelected() ? SwingConstants.HORIZONTAL : SwingConstants.VERTICAL));
+        chDisablePast.addActionListener(e -> {
+            boolean disable = chDisablePast.isSelected();
+            if (disable) {
+                disablePast();
+            } else {
+                timePicker.setTimeSelectionAble(null);
+            }
+        });
         panel.add(ch24hourView);
         panel.add(chHorizontal);
+        panel.add(chDisablePast);
         add(panel);
     }
 
+    private void disablePast() {
+        timePicker.setTimeSelectionAble((time, hourView) -> {
+            LocalTime now = LocalTime.now().withSecond(0).withNano(0);
+            if (hourView) {
+                // use this to enable the hour selection on the PanelClock
+                return time.getHour() >= now.getHour();
+            }
+            return !time.isBefore(now);
+        });
+    }
 
     public static void main(String[] args) {
         FlatRobotoFont.install();


### PR DESCRIPTION
This PR update add time selection able and editor input validation

## Time selection able
Use class `TimeSelectionAble` from package: `raven.datetime.TimeSelectionAble`

#### Example to disable the past time
``` java
// create timepicker object
TimePicker timePicker = new TimePicker();

// set time selection able
timePicker.setTimeSelectionAble((time, hourView) -> {
    LocalTime now = LocalTime.now().withSecond(0).withNano(0);
    if (hourView) {
        // use this to enable the hour selection on the PanelClock
        return time.getHour() >= now.getHour();
    }
    return !time.isBefore(now);
});
```

### Example to disable the future time
``` java
timePicker.setTimeSelectionAble((time, hourView) -> {
    LocalTime now = LocalTime.now();
    return !time.isAfter(now);
});
```
or this for single line code
``` java
timePicker.setTimeSelectionAble((time, hourView) -> !time.isAfter(LocalTime.now()));
```
![2024-12-20_192426](https://github.com/user-attachments/assets/86ab4b06-8969-4f41-be56-9dab530a658a)

## Editor input validation

- By default it's enabled. to disable it use method: `timePicker.setEditorValidation(false);`

![image](https://github.com/user-attachments/assets/51b5d02f-3f1c-428e-bf2a-575138d9c852)

- Validateion on null selection. by default it's disabled. to enable use method `timePicker.setValidationOnNull(true)`

![image](https://github.com/user-attachments/assets/5c0e892d-044a-4f2e-9f89-ba5ad556ae70)

Editor also validation with the time selection able (when user input the disabled date)

#### Output ( disable the time selection before `08:00 PM` )
![image](https://github.com/user-attachments/assets/7b264063-985c-4900-9f56-591a34179f94)

![image](https://github.com/user-attachments/assets/7d720fc2-260f-4244-821b-e9d875ad9516)

