### PR TITLE
DatePicker: add new option `defaultDateCellRenderer` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.2]-SNAPSHOT
+
+### New features and improvements
+
+- DatePicker:
+    - Add new option `defaultDateCellRenderer` to custom date cell renderer
+
 ## [2.1.1] - 2025-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Add the snapshot version
 
 ## Usage DatePicker
 | Method                                                 | Return Value | Description |
-|--------------------------------------------------------| ------------ | ------------ |
+|--------------------------------------------------------| ----------- | ------------ |
 | now()                                                  | | set the date to current local date |
 | setToBack()                                            | | slide panel to back with animation |
 | setToForward()                                         | | slide panel to forward with animation |
@@ -108,6 +108,7 @@ Add the snapshot version
 | void setPopupSpace(Point popupSpace) | | set the popup space with component or editor |
 | void setHourSelectionView(boolean hourSelectionView) | | show hour or minute selection state |
 | void setSelectionArc(float selectionArc) | | set date selection border arc |
+| void setDefaultDateCellRenderer(DefaultDateCellRenderer renderer) | | set date cell renderer to paint custom graphics |
 
 ## Library Resources
 - [FlatLaf](https://github.com/JFormDesigner/FlatLaf) - FlatLaf library for the modern UI design theme

--- a/src/main/java/raven/datetime/DatePicker.java
+++ b/src/main/java/raven/datetime/DatePicker.java
@@ -50,6 +50,7 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
     private PanelMonth panelMonth;
     private PanelYear panelYear;
 
+    private DefaultDateCellRenderer defaultDateCellRenderer = new DefaultDateCellRenderer();
     private final Header header = new Header();
     private final PanelSlider panelSlider = new PanelSlider();
 
@@ -462,6 +463,15 @@ public class DatePicker extends PanelPopupEditor implements DateSelectionModelLi
 
     public void removeDateSelectionListener(DateSelectionListener listener) {
         listenerList.remove(DateSelectionListener.class, listener);
+    }
+
+    public DefaultDateCellRenderer getDefaultDateCellRenderer() {
+        return defaultDateCellRenderer;
+    }
+
+    public void setDefaultDateCellRenderer(DefaultDateCellRenderer defaultDateCellRenderer) {
+        this.defaultDateCellRenderer = defaultDateCellRenderer;
+        repaint();
     }
 
     public Header getHeader() {

--- a/src/main/java/raven/datetime/component/date/DefaultDateCellRenderer.java
+++ b/src/main/java/raven/datetime/component/date/DefaultDateCellRenderer.java
@@ -1,0 +1,166 @@
+package raven.datetime.component.date;
+
+import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.ui.FlatUIUtils;
+import com.formdev.flatlaf.util.ColorFunctions;
+import com.formdev.flatlaf.util.UIScale;
+import raven.datetime.DatePicker;
+import raven.datetime.util.Utils;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.Area;
+import java.awt.geom.Rectangle2D;
+
+public class DefaultDateCellRenderer {
+
+    public void paint(Graphics2D g2, DatePicker datePicker, ButtonDate component, SingleDate date, float width, float height) {
+
+        // paint selection
+        float arc = getArc(datePicker);
+        boolean isSelected = component.isDateSelected();
+        paintDateSelection(g2, datePicker, component, isSelected, width, height, arc);
+
+        //  paint date between selected
+        DateSelectionModel dateSelectionModel = datePicker.getDateSelectionModel();
+        if (dateSelectionModel.getDateSelectionMode() == DatePicker.DateSelectionMode.BETWEEN_DATE_SELECTED && dateSelectionModel.getDate() != null) {
+            paintBetweenDateSelection(g2, datePicker, component, date, width, height, arc);
+        }
+        if (date.same(new SingleDate())) {
+            paintCurrentDate(g2, datePicker, component, date, isSelected, width, height, arc);
+        }
+    }
+
+    /**
+     * Paint cell selection or cell focused
+     */
+    protected void paintDateSelection(Graphics2D g2, DatePicker datePicker, ButtonDate component, boolean isSelected, float width, float height, float arc) {
+        Rectangle2D.Float rec = getRectangle(width, height);
+        g2.setColor(getSelectionColor(datePicker, component, isSelected));
+        g2.fill(FlatUIUtils.createComponentRectangle(rec.x, rec.y, rec.width, rec.height, arc));
+    }
+
+    protected void paintBetweenDateSelection(Graphics2D g2, DatePicker datePicker, ButtonDate component, SingleDate date, float width, float height, float arc) {
+        g2.setColor(getBetweenDateColor(datePicker, component));
+        DateSelectionModel dateSelectionModel = datePicker.getDateSelectionModel();
+        Rectangle2D.Float rec = getRectangle(width, height);
+        int rowIndex = component.getRowIndex();
+        if (date.between(dateSelectionModel.getDate(), getToDate(datePicker))) {
+            if (rowIndex == 0) {
+                g2.fill(createShape(rec.x, rec.y, width, rec.height, arc, true, true));
+            } else if (rowIndex == 6) {
+                g2.fill(createShape(rec.x, rec.y, width, rec.height, arc, false, true));
+            } else {
+                g2.fill(new Rectangle2D.Float(0, rec.y, width, rec.height));
+            }
+        }
+        if (!dateSelectionModel.getDate().same(getToDate(datePicker))) {
+            boolean right = dateSelectionModel.getDate().before(getToDate(datePicker));
+            if (date.same(dateSelectionModel.getDate())) {
+                if ((right && rowIndex != 6) || !right && rowIndex != 0) {
+                    g2.fill(createShape(rec.x, rec.y, width, rec.height, arc, right, false));
+                }
+            }
+            if (date.same(getToDate(datePicker))) {
+                if ((right && rowIndex != 0) || (!right && rowIndex != 6)) {
+                    g2.fill(createShape(rec.x, rec.y, width, rec.height, arc, !right, !component.isHover() && dateSelectionModel.getToDate() == null));
+                }
+            }
+        }
+    }
+
+    protected void paintCurrentDate(Graphics2D g2, DatePicker datePicker, ButtonDate component, SingleDate date, boolean isSelected, float width, float height, float arc) {
+        Rectangle2D.Float rec = getRectangle(width, height);
+        float fw = getSelectedFocusWidth();
+        float space = UIScale.scale(isSelected ? fw : 0);
+        if (space > 0) {
+            rec.x -= space;
+            rec.y -= space;
+            rec.width += space * 2f;
+            rec.height += space * 2f;
+        }
+        Area area = new Area(FlatUIUtils.createComponentRectangle(rec.x, rec.y, rec.width, rec.height, arc));
+        if (isSelected) {
+            float s = UIScale.scale(fw + 1f);
+            area.subtract(new Area(FlatUIUtils.createComponentRectangle(rec.x + s, rec.x + s, rec.width - s * 2f, rec.height - s * 2f, arc - s)));
+        } else {
+            float s = UIScale.scale(fw);
+            area.subtract(new Area(FlatUIUtils.createComponentRectangle(rec.x + s, rec.y + s, rec.width - s * 2f, rec.height - s * 2f, arc - s)));
+        }
+        Color accentColor = getAccentColor(datePicker);
+        g2.setColor(isSelected ? getBorderColor(component, accentColor) : accentColor);
+        g2.fill(area);
+    }
+
+    private SingleDate getToDate(DatePicker datePicker) {
+        DateSelectionModel dateSelectionModel = datePicker.getDateSelectionModel();
+        return dateSelectionModel.getToDate() != null ? dateSelectionModel.getToDate() : dateSelectionModel.getHoverDate();
+    }
+
+    protected Shape createShape(float x, float y, float width, float size, float arc, boolean right, boolean add) {
+        Area area;
+        if (right) {
+            area = new Area(new Rectangle2D.Float(width / 2, y, width / 2, size));
+            area.subtract(new Area(FlatUIUtils.createComponentRectangle(x, y, size, size, arc)));
+        } else {
+            area = new Area(new Rectangle2D.Float(0, y, width / 2, size));
+        }
+        if (add) {
+            area.add(new Area(FlatUIUtils.createComponentRectangle(x, y, size, size, arc)));
+        } else {
+            area.subtract(new Area(FlatUIUtils.createComponentRectangle(x, y, size, size, arc)));
+        }
+        return area;
+    }
+
+    protected Color getBorderColor(ButtonDate component, Color color) {
+        return ColorFunctions.mix(color, component.getParent().getBackground(), 0.45f);
+    }
+
+    protected Color getBetweenDateColor(DatePicker datePicker, ButtonDate component) {
+        Color color = FlatUIUtils.getParentBackground(component);
+        if (datePicker.getDateSelectionModel().getToDate() != null) {
+            return ColorFunctions.mix(color, getAccentColor(datePicker), 0.9f);
+        }
+        return FlatLaf.isLafDark() ? ColorFunctions.lighten(color, 0.03f) : ColorFunctions.darken(color, 0.03f);
+    }
+
+    /**
+     * Get selection color, focused color or isPress and isHover color
+     */
+    protected Color getSelectionColor(DatePicker datePicker, ButtonDate component, boolean isSelected) {
+        // use component parent background as the focused color
+        Color color = FlatUIUtils.getParentBackground(component);
+        if (isSelected) {
+            // use accent color as selection color
+            color = getAccentColor(datePicker);
+        }
+        return Utils.getColor(color, component.isPress(), component.isHover());
+    }
+
+    protected Color getAccentColor(DatePicker datePicker) {
+        if (datePicker.getColor() != null) {
+            return datePicker.getColor();
+        }
+        return UIManager.getColor("Component.accentColor");
+    }
+
+    protected float getCellPadding() {
+        return 7f;
+    }
+
+    protected float getSelectedFocusWidth() {
+        return 2f;
+    }
+
+    protected float getArc(DatePicker datePicker) {
+        return datePicker.getSelectionArc();
+    }
+
+    protected Rectangle2D.Float getRectangle(float width, float height) {
+        float size = Math.min(width, height) - UIScale.scale(getCellPadding());
+        float x = (width - size) / 2f;
+        float y = (height - size) / 2f;
+        return new Rectangle2D.Float(x, y, size, size);
+    }
+}

--- a/src/test/java/test/renderer/CustomDateCellRenderer.java
+++ b/src/test/java/test/renderer/CustomDateCellRenderer.java
@@ -1,0 +1,83 @@
+package test.renderer;
+
+import com.formdev.flatlaf.util.UIScale;
+import raven.datetime.DatePicker;
+import raven.datetime.component.date.ButtonDate;
+import raven.datetime.component.date.DefaultDateCellRenderer;
+import raven.datetime.component.date.SingleDate;
+
+import java.awt.*;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Rectangle2D;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomDateCellRenderer extends DefaultDateCellRenderer {
+
+    private List<DateStatus> list;
+
+    public CustomDateCellRenderer() {
+        // init list
+        list = new ArrayList<>();
+        list.add(new DateStatus(LocalDate.of(2025, 5, 12), LabelDate.MOSTLY_BOOKED));
+        list.add(new DateStatus(LocalDate.of(2025, 5, 13), LabelDate.FREE));
+        list.add(new DateStatus(LocalDate.of(2025, 5, 16), LabelDate.FULLY_BOOKED));
+        list.add(new DateStatus(LocalDate.of(2025, 5, 20), LabelDate.SOME_SLOTS));
+        list.add(new DateStatus(LocalDate.of(2025, 5, 23), LabelDate.MOSTLY_BOOKED));
+        list.add(new DateStatus(LocalDate.of(2025, 5, 28), LabelDate.MOSTLY_FREE));
+
+        list.add(new DateStatus(LocalDate.of(2025, 6, 26), LabelDate.SOME_SLOTS));
+    }
+
+    @Override
+    public void paint(Graphics2D g2, DatePicker datePicker, ButtonDate component, SingleDate date, float width, float height) {
+        super.paint(g2, datePicker, component, date, width, height);
+        LabelDate labelDate = getLabelDate(date.toLocalDate());
+        if (labelDate != null) {
+            g2.setColor(labelDate.getColor());
+
+            // use rendering hint to control draw strokes line
+            g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+            g2.setStroke(new BasicStroke(UIScale.scale(getSelectedFocusWidth()), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER));
+            Rectangle2D.Float rec = getRectangle(width, height);
+            g2.draw(new Arc2D.Float(rec, 90, 360 * labelDate.getValue(), Arc2D.OPEN));
+        }
+    }
+
+    private LabelDate getLabelDate(LocalDate date) {
+        for (DateStatus d : list) {
+            if (d.getDate().equals(date)) {
+                return d.getLabel();
+            }
+        }
+        return null;
+    }
+
+    private class DateStatus {
+
+        public LocalDate getDate() {
+            return date;
+        }
+
+        public void setDate(LocalDate date) {
+            this.date = date;
+        }
+
+        public LabelDate getLabel() {
+            return label;
+        }
+
+        public void setLabel(LabelDate label) {
+            this.label = label;
+        }
+
+        public DateStatus(LocalDate date, LabelDate label) {
+            this.date = date;
+            this.label = label;
+        }
+
+        private LocalDate date;
+        private LabelDate label;
+    }
+}

--- a/src/test/java/test/renderer/LabelDate.java
+++ b/src/test/java/test/renderer/LabelDate.java
@@ -1,0 +1,34 @@
+package test.renderer;
+
+import java.awt.*;
+
+public enum LabelDate {
+
+    FREE("Free", new Color(59, 155, 60), 1f),
+    MOSTLY_BOOKED("Mostly Booked", new Color(239, 138, 138), 0.75f),
+    SOME_SLOTS("Some Slots", new Color(213, 189, 44), 0.5f),
+    FULLY_BOOKED("Fully Booked", new Color(231, 41, 41), 1f),
+    MOSTLY_FREE("Mostly Free", new Color(140, 225, 141), 0.75f);
+
+    private final String name;
+    private final Color color;
+    private final float value;
+
+    LabelDate(String name, Color color, float value) {
+        this.name = name;
+        this.color = color;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public float getValue() {
+        return value;
+    }
+}

--- a/src/test/java/test/renderer/TestDateCellRenderer.java
+++ b/src/test/java/test/renderer/TestDateCellRenderer.java
@@ -1,0 +1,49 @@
+package test.renderer;
+
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import net.miginfocom.swing.MigLayout;
+import raven.datetime.DatePicker;
+import test.TestFrame;
+
+import java.awt.*;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class TestDateCellRenderer extends TestFrame {
+
+    public TestDateCellRenderer() {
+        setLayout(new MigLayout(""));
+        DatePicker datePicker = new DatePicker();
+        datePicker.setDateSelectionMode(DatePicker.DateSelectionMode.BETWEEN_DATE_SELECTED);
+        datePicker.addDateSelectionListener(dateEvent -> {
+            DateTimeFormatter df = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+            if (datePicker.getDateSelectionMode() == DatePicker.DateSelectionMode.SINGLE_DATE_SELECTED) {
+                LocalDate date = datePicker.getSelectedDate();
+                if (date != null) {
+                    System.out.println("date change " + df.format(datePicker.getSelectedDate()));
+                } else {
+                    System.out.println("date change to null");
+                }
+            } else {
+                LocalDate dates[] = datePicker.getSelectedDateRange();
+                if (dates != null) {
+                    System.out.println("date change " + df.format(dates[0]) + " to " + df.format(dates[1]));
+                } else {
+                    System.out.println("date change to null");
+                }
+            }
+        });
+
+        datePicker.setDefaultDateCellRenderer(new CustomDateCellRenderer());
+        datePicker.setSelectedDate(LocalDate.of(2025, 5, 10));
+        // date picker minimum size 300px
+        add(datePicker, "width 300::,height 330::");
+    }
+
+
+    public static void main(String[] args) {
+        // System.setProperty("flatlaf.uiScale", "150%");
+        FlatMacDarkLaf.setup();
+        EventQueue.invokeLater(() -> new TestDateCellRenderer().setVisible(true));
+    }
+}


### PR DESCRIPTION
This PR update add `defaultDateCellRenderer` to custom date cell renderer (issue #18)

#### Example

``` java
datePicker.setDefaultDateCellRenderer(new CustomDateCellRenderer());
```

#### Example class custom cell renderer

``` java
import raven.datetime.component.date.DefaultDateCellRenderer;

public class CustomDateCellRenderer extends DefaultDateCellRenderer {

    @Override
    public void paint(Graphics2D g2, DatePicker datePicker, ButtonDate component,
                      SingleDate date, float width, float height) {
        
        super.paint(g2, datePicker, component, date, width, height);

        // custom paint graphics here
    }
}
```
![update](https://github.com/user-attachments/assets/648fb963-7182-4324-89f4-8edd4e181b03)


