### PR TITLE
Fix bug click option in PanelDateOption

### DIFF
--- a/src/main/java/raven/datetime/PanelDateOption.java
+++ b/src/main/java/raven/datetime/PanelDateOption.java
@@ -66,11 +66,14 @@ public class PanelDateOption extends JPanel {
                 if (dates.length == 0) {
                     throw new IllegalArgumentException("Date option is empty so can't be select");
                 }
-                boolean singleDate = dates.length == 1 || datePicker.getDateSelectionMode() == DatePicker.DateSelectionMode.SINGLE_DATE_SELECTED;
+                boolean singleDate = DatePicker.DateSelectionMode.SINGLE_DATE_SELECTED.equals(datePicker.getDateSelectionMode());
                 if (isEnable) {
                     if (singleDate) {
                         datePicker.setSelectedDate(dates[0]);
                     } else {
+                        if (dates.length < 2) {
+                            dates = new LocalDate[]{dates[0], dates[0]};
+                        }
                         datePicker.setSelectedDateRange(dates[0], dates[1]);
                     }
                 } else {


### PR DESCRIPTION
#### Options
- [x] Use date between
- [x] Use panel option

#### Action
When clicking a 'panel option' button for example the 'today' option, you need to click an option that has two dates to be selected for it to be 'released,' and then click 'today' again to use it correctly.